### PR TITLE
Added simple php switch for interactive mode in installer

### DIFF
--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -9,9 +9,15 @@ fi
 echo '[composer] Downloading the bundle'
 composer require "gnugat/wizard-bundle:~1"
 
+PHP_VERSION=`php -v`
+PHP_OPEN_TAG=''
+if ( echo $PHP_VERSION | grep -vq "PHP 5.5" ); then
+    PHP_OPEN_TAG='<?php'
+fi
+
 echo '[php] Subscribing to the post-package-install event'
 php -a <<EOF
-<?php
+$PHP_OPEN_TAG 
 \$composerConfigFile = file_get_contents('composer.json');
 \$composerConfig = json_decode(\$composerConfigFile, true);
 


### PR DESCRIPTION
This should fix the problem explained in #15. In PHP <= 5.4 php open tag is required in interactive mode, in PHP 5.5 it causes a parse error.
This is a really quickhacked workaround for using this bundle on my current PHP 5.5 machines. If you now a more elegant way do it this way :)
