### PR TITLE
Stability issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         "symfony/console": ">=2.3,<3.0",
         "symfony/validator": ">=2.3,<3.0",
 
-        "composer/composer": "~1.0@alpha",
-
         "sensio/generator-bundle": ">=2.3,<3.0"
     },
     "require-dev": {
         "behat/behat": "~3.0@beta",
         "phpspec/phpspec": "~2.0@beta",
         "phpunit/phpunit": "~3.7",
+
+        "composer/composer": "~1.0@alpha",
 
         "symfony/form": ">=2.3,<3.0"
     },


### PR DESCRIPTION
Currently it is not possible that via the default way

```
composer require "gnugat/wizard-bundle:~1"
```

from the installer a newer version than 1.0.1 could be installed.

The newer versions are marked as alpha because of the [@alpha requirement of composer](https://github.com/gnugat/GnugatWizardBundle/blob/master/composer.json#L17) and thus they will not be taken into account for projects with `minimum-stability: stable`.

This means that this bundle could not be correctly installed from a default Symfony 2.3 project. The `post-package-install` composer settings links to some event listener which is not available in release 1.0.1.

All in all this bundle does nothing after a bundle requirement in a SF 2.3 project.
