### PR TITLE
Prevent "Uninitialized string offset: 0" exception when $paths is ""

### DIFF
--- a/Provider/ComposerEventPackage.php
+++ b/Provider/ComposerEventPackage.php
@@ -40,8 +40,6 @@ class ComposerEventPackage implements ComposerPackageProvider
      */
     public function getPackage($name)
     {
-        $packages = array();
-
         $autoload = $this->composerEventPackage->getAutoload();
 
         $autoloadNamespaces = array();


### PR DESCRIPTION
Debugging the code I noticed that an exception is thrown when the $paths is an empty string. I was running `composer require jms/di-extra-bundle:dev-master` and for jms/aop-bundle $autoloadNamespaces is:

``` php
array (
  'JMS\\AopBundle' => '',
)
```

Is the check ok or do you prefer `strlen($paths)`?

Should I remove the unused `$packages = array();` in line 43 while I’m at it?
